### PR TITLE
Use BasicURLHandler instead of okhttp variant to support newer SBT versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,6 @@ sbtPlugin := true
 
 name := "publish-with-headers"
 organization := "org.jboss.pnc.sbt.plugins"
-version := "0.0.1"
+version := "0.0.2-SNAPSHOT"
 
 publishMavenStyle := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.12
+sbt.version = 1.9.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.3
+sbt.version = 1.9.9

--- a/src/main/scala/org/jboss/pnc/sbt/plugins/PublishWithHeadersPlugin.scala
+++ b/src/main/scala/org/jboss/pnc/sbt/plugins/PublishWithHeadersPlugin.scala
@@ -18,7 +18,6 @@
 
 package org.jboss.pnc.sbt.plugins
 
-import okhttp3.Headers
 import sbt.Keys._
 import sbt.{Def, _}
 import org.apache.ivy.util.url._
@@ -35,9 +34,9 @@ object PublishWithHeadersPlugin extends AutoPlugin with PublishWithHeadersKeys {
       log.info(s"Updating urlHandlerDispatcher to use PublishWithHeadersPlugin")
       val urlHandlerDispatcher = new URLHandlerDispatcher {
         super.setDownloader("http", new WithHeadersURLHandler(
-          Headers.of(Strings.toMap(headers.value))))
+          Strings.toMap(headers.value)))
         super.setDownloader("https", new WithHeadersURLHandler(
-          Headers.of(Strings.toMap(headers.value))))
+          Strings.toMap(headers.value)))
         override def setDownloader(protocol: String, downloader: URLHandler): Unit = {}
       }
       URLHandlerRegistry.setDefault(urlHandlerDispatcher)

--- a/src/main/scala/org/jboss/pnc/sbt/plugins/Strings.java
+++ b/src/main/scala/org/jboss/pnc/sbt/plugins/Strings.java
@@ -18,10 +18,8 @@
 
 package org.jboss.pnc.sbt.plugins;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/src/main/scala/org/jboss/pnc/sbt/plugins/WithHeadersURLHandler.scala
+++ b/src/main/scala/org/jboss/pnc/sbt/plugins/WithHeadersURLHandler.scala
@@ -18,60 +18,160 @@
 
 package org.jboss.pnc.sbt.plugins
 
-import gigahorse.support.okhttp.Gigahorse
-import okhttp3.{Headers, MediaType, OkHttpClient, Request, RequestBody, Response}
-import org.apache.ivy.util.{CopyProgressEvent, CopyProgressListener, Message}
-import org.apache.ivy.util.url.IvyAuthenticator
+import org.apache.ivy.Ivy
+import org.apache.ivy.util.url.{BasicURLHandler, IvyAuthenticator}
+import org.apache.ivy.util.{CopyProgressListener, FileUtil, Message}
 import sbt.{File, URL}
-import sbt.internal.librarymanagement.ivyint.{ErrorMessageAuthenticator, GigahorseUrlHandler}
 
-object URLHandlerHelper {
-  lazy val http: OkHttpClient = {
-    Gigahorse.http(Gigahorse.config)
-      .underlying[OkHttpClient]
-      .newBuilder()
-      .authenticator(new sbt.internal.librarymanagement.JavaNetAuthenticator)
-      .followRedirects(true)
-      .followSslRedirects(true)
-      .build
-  }
-}
+import java.io.{ByteArrayOutputStream, FileInputStream, IOException, InputStream}
+import java.net.{HttpURLConnection, URLConnection}
+import java.util
 
-class WithHeadersURLHandler(headers: Headers) extends GigahorseUrlHandler(URLHandlerHelper.http) {
+class WithHeadersURLHandler(headers: java.util.Map[String,String]) extends BasicURLHandler() {
 
-  private val EmptyBuffer: Array[Byte] = new Array[Byte](0)
+  private val BUFFER_SIZE = 64 * 1024
+  private val ERROR_BODY_TRUNCATE_LEN = 512
+  override def upload(source: File, dest: URL, l: CopyProgressListener): Unit = {
 
-  override def upload(source: File, dest0: URL, l: CopyProgressListener): Unit = {
+    if (!("http" == dest.getProtocol) && !("https" == dest.getProtocol)) throw new UnsupportedOperationException("URL repository only support HTTP PUT at the moment")
 
-    if (("http" != dest0.getProtocol) && ("https" != dest0.getProtocol)) {
-      throw new UnsupportedOperationException("URL repository only support HTTP PUT at the moment")
-    }
-    Message.debug("Uploading using WithHeadersURLHandler...")
-
+    // Install the IvyAuthenticator// Install the IvyAuthenticator
     IvyAuthenticator.install()
-    ErrorMessageAuthenticator.install()
 
-    val dest = normalizeToURL(dest0)
-
-    val body = RequestBody.create(MediaType.parse("application/octet-stream"), source)
-
-    val request = new Request.Builder()
-      .url(dest)
-      .headers(headers)
-      .put(body)
-      .build()
-
-    if (l != null) {
-      l.start(new CopyProgressEvent())
-    }
-    val response = URLHandlerHelper.http.newCall(request).execute()
+    var conn: HttpURLConnection = null
     try {
-      if (l != null) {
-        l.end(new CopyProgressEvent(EmptyBuffer, source.length()))
+      val normalDest = normalizeToURL(dest)
+      conn = normalDest.openConnection.asInstanceOf[HttpURLConnection]
+      conn.setDoOutput(true)
+      conn.setRequestMethod("PUT")
+      conn.setRequestProperty("User-Agent", "Apache Ivy/" + Ivy.getIvyVersion)
+      conn.setRequestProperty("Accept", "application/octet-stream, application/json, application/xml, */*")
+      conn.setRequestProperty("Content-type", "application/octet-stream")
+      conn.setRequestProperty("Content-length", source.length.toString)
+      headers.entrySet().forEach(entry => conn.setRequestProperty(entry.getKey, entry.getValue))
+      conn.setInstanceFollowRedirects(true)
+      val in = new FileInputStream(source)
+      try {
+        val os = conn.getOutputStream
+        FileUtil.copy(in, os, l)
+      } finally try in.close()
+      catch {
+        case _: IOException =>
       }
-      validatePutStatusCode(dest, response.code(), response.message())
-    } finally {
-      response.close()
+      // initiate the connection
+      val responseCode = conn.getResponseCode
+      var extra = ""
+      val errorStream = conn.getErrorStream
+      val responseStream = conn.getInputStream
+      if (errorStream != null) extra = "; Response Body: " + readTruncated(errorStream, ERROR_BODY_TRUNCATE_LEN, conn.getContentType, conn.getContentEncoding)
+      else if (responseStream != null) {
+        val decodingStream = getDecodingInputStream(conn.getContentEncoding, responseStream)
+        extra = "; Response Body: " + readTruncated(responseStream, ERROR_BODY_TRUNCATE_LEN, conn.getContentType, conn.getContentEncoding)
+      }
+      Message.debug("Response Headers:" + getHeadersAsDebugString(conn.getHeaderFields))
+      validatePutStatusCode(dest, responseCode, conn.getResponseMessage + extra)
+    } finally disconnect(conn)
+  }
+
+  @throws[IOException]
+  private def getHeadersAsDebugString(headers: util.Map[String, util.List[String]]): String = {
+    val builder: StringBuilder = new StringBuilder("")
+    if (headers != null) {
+      import scala.collection.JavaConversions.*
+      for (header <- headers.entrySet) {
+        val key: String = header.getKey
+        if (key != null) {
+          builder.append(header.getKey)
+          builder.append(": ")
+        }
+        builder.append(String.join("\n    ", header.getValue))
+        builder.append("\n")
+      }
+    }
+    builder.toString
+  }
+  /**
+   * Extract the charset from the Content-Type header string, or default to ISO-8859-1 as per
+   * rfc2616-sec3.html#sec3.7.1 .
+   *
+   * @param contentType
+   * the Content-Type header string
+   * @return the charset as specified in the content type, or ISO-8859-1 if unspecified.
+   */
+  private def getCharSetFromContentType(contentType: String): String = {
+    var charSet: String = null
+    if (contentType != null) {
+      val elements = contentType.split(";")
+      for (i <- 0 until elements.length) {
+        val element = elements(i).trim
+        if (element.toLowerCase.startsWith("charset=")) charSet = element.substring("charset=".length)
+      }
+    }
+    if (charSet == null || charSet.isEmpty) {
+      // default to ISO-8859-1 as per rfc2616-sec3.html#sec3.7.1
+      charSet = "ISO-8859-1"
+    }
+    charSet
+  }
+
+  @throws[IOException]
+  private def readTruncated(is: InputStream, maxLen: Int, contentType: String, contentEncoding: String) = {
+    val decodingStream = getDecodingInputStream(contentEncoding, is)
+    val charSet = getCharSetFromContentType(contentType)
+    val os = new ByteArrayOutputStream(maxLen)
+    try {
+      var count = 0
+      var b = decodingStream.read
+      while (count < maxLen && b >= 0) {
+        os.write(b)
+        count += 1
+        b = decodingStream.read
+      }
+      new String(os.toByteArray, charSet)
+    } finally try is.close()
+    catch {
+      case _: IOException =>
+    }
+  }
+  private def disconnect(con: URLConnection): Unit = {
+    con match {
+      case connection: HttpURLConnection =>
+        if (!("HEAD" == connection.getRequestMethod)) {
+          // We must read the response body before disconnecting!
+          // Cfr. http://java.sun.com/j2se/1.5.0/docs/guide/net/http-keepalive.html
+          // [quote]Do not abandon a connection by ignoring the response body. Doing
+          // so may results in idle TCP connections.[/quote]
+          readResponseBody(connection)
+        }
+        connection.disconnect()
+      case _ => if (con != null) try con.getInputStream.close()
+      catch {
+        case _: IOException =>
+      }
+    }
+  }
+
+  private def readResponseBody(conn: HttpURLConnection): Unit = {
+    val buffer = new Array[Byte](BUFFER_SIZE)
+    var inStream: InputStream = null
+    try {
+      inStream = conn.getInputStream
+      while (inStream.read(buffer) > 0) {
+      }
+    } catch {
+      case _: IOException =>
+    } finally if (inStream != null) try inStream.close()
+    catch {
+      case _: IOException =>
+    }
+    val errStream = conn.getErrorStream
+    if (errStream != null) try while (errStream.read(buffer) > 0) {
+    }
+    catch {
+      case _: IOException =>
+    } finally try errStream.close()
+    catch {
+      case _: IOException =>
     }
   }
 }


### PR DESCRIPTION
When trying to `whPublish` a project using a newer SBT version like 1.9.3 we see exceptions like:
```
[error] java.lang.NoClassDefFoundError: sbt/internal/librarymanagement/ivyint/GigahorseUrlHandler
[error]     at org.jboss.pnc.sbt.plugins.PublishWithHeadersPlugin$$anon$1.<init>(PublishWithHeadersPlugin.scala:37)
[error]     at org.jboss.pnc.sbt.plugins.PublishWithHeadersPlugin$.$anonfun$projectSettings$3(PublishWithHeadersPlugin.scala:36)
[error]     at org.jboss.pnc.sbt.plugins.PublishWithHeadersPlugin$.$anonfun$projectSettings$3$adapted(PublishWithHeadersPlugin.scala:33)
```

`okhttp` and the `GigahorseUrlHandler` were removed from [SBT in 1.7.0](https://github.com/sbt/librarymanagement/commit/76452e53ff6f7211db2bab5dd3bc8f06dac1bbce) for security reasons and instead they use an BasicURLHandler based on URLConnection.

Downgrading SBT is no longer a simple fix when trying to build scala 2.13.11+ as the project has some tight integration with SBT, so it makes sense to make the plugin compatible with newer SBT versions.

This change updates the plugin to be based on the `BasicURLHandler` (unfortunately a lot of the private guts of the class had to be copied and switched to scala to keep the same behaviour, just adding the extra headers in)

I tested that it worked with a local nexus repository and observed the headers being set on PUT requests.